### PR TITLE
Nextsteps

### DIFF
--- a/decepticon/__init__.py
+++ b/decepticon/__init__.py
@@ -12,4 +12,5 @@ from decepticon._models import build_mask_generator
 from decepticon._models import build_discriminator, build_mask_discriminator
 from decepticon._synthetic import build_synthetic_dataset, build_inpainter_dataset
 from decepticon._trainers import Trainer
+from decepticon._util import load_trainer_from_saved
 import decepticon.loaders

--- a/decepticon/_descriptions.py
+++ b/decepticon/_descriptions.py
@@ -96,12 +96,12 @@ Pixel-wise score for fake parts of the image
 """
 
 loss_descriptions = defaultdict(str)
-loss_descriptions["mask_generator_total_loss"]:maskgen
-loss_descriptions["mask_generator_classifier_loss"]:cls_loss
-loss_descriptions["mask_generator_exponential_loss"]:exp_loss
-loss_descriptions["mask_generator_prior_loss"]:prior_loss
-loss_descriptions["inpainter_style_loss"]:style_loss
-loss_descriptions["inpainter_total_loss"]:inpainter_total_loss
-loss_descriptions["inpainter_reconstruction_L1_loss"]:recon_loss
-loss_descriptions["discriminator_GAN_loss"]:disc_loss
-loss_descriptions["mask_discriminator_loss"]:maskdisc_loss
+loss_descriptions["mask_generator_total_loss"] = maskgen
+loss_descriptions["mask_generator_classifier_loss"] = cls_loss
+loss_descriptions["mask_generator_exponential_loss"] = exp_loss
+loss_descriptions["mask_generator_prior_loss"] = prior_loss
+loss_descriptions["inpainter_style_loss"] = style_loss
+loss_descriptions["inpainter_total_loss"] = inpainter_total_loss
+loss_descriptions["inpainter_reconstruction_L1_loss"] = recon_loss
+loss_descriptions["discriminator_GAN_loss"] = disc_loss
+loss_descriptions["mask_discriminator_loss"] = maskdisc_loss

--- a/decepticon/_descriptions.py
+++ b/decepticon/_descriptions.py
@@ -1,5 +1,5 @@
 # markdown descriptions for tensorboard outputs go here
-
+from collections import defaultdict
 
 maskgen = """
 # Mask generator total loss
@@ -95,14 +95,13 @@ disc_score_fake="""
 Pixel-wise score for fake parts of the image
 """
 
-loss_descriptions = {
-                    "mask_generator_total_loss":maskgen,
-                    "mask_generator_classifier_loss":cls_loss,
-                    "mask_generator_exponential_loss":exp_loss,
-                    "mask_generator_prior_loss":prior_loss,
-                    "inpainter_style_loss":style_loss,
-                    "inpainter_total_loss":inpainter_total_loss,
-                    "inpainter_reconstruction_L1_loss":recon_loss,
-                    "discriminator_GAN_loss":disc_loss,
-                    "mask_discriminator_loss":maskdisc_loss
-                    }
+loss_descriptions = defaultdict(str)
+loss_descriptions["mask_generator_total_loss"]:maskgen
+loss_descriptions["mask_generator_classifier_loss"]:cls_loss
+loss_descriptions["mask_generator_exponential_loss"]:exp_loss
+loss_descriptions["mask_generator_prior_loss"]:prior_loss
+loss_descriptions["inpainter_style_loss"]:style_loss
+loss_descriptions["inpainter_total_loss"]:inpainter_total_loss
+loss_descriptions["inpainter_reconstruction_L1_loss"]:recon_loss
+loss_descriptions["discriminator_GAN_loss"]:disc_loss
+loss_descriptions["mask_discriminator_loss"]:maskdisc_loss

--- a/decepticon/_descriptions.py
+++ b/decepticon/_descriptions.py
@@ -28,6 +28,13 @@ prior_loss = """
 
 Helps bias mask generator toward compact masks
 """
+maskgen_tv_loss = """
+# Total variation loss for mask generator
+"""
+
+inpainter_tv_loss = """
+# Total variation loss for inpainter
+"""
 
 
 inpainter_total_loss="""
@@ -95,6 +102,14 @@ disc_score_fake="""
 Pixel-wise score for fake parts of the image
 """
 
+mask_variance="""
+# Mask Variance
+
+The average variance of each pixel across a batch of masks.
+
+* This isn't used as a loss, but in cases where we've seen mode collapse we'd expect it to drop to zero.
+"""
+
 loss_descriptions = defaultdict(str)
 loss_descriptions["mask_generator_total_loss"] = maskgen
 loss_descriptions["mask_generator_classifier_loss"] = cls_loss
@@ -105,3 +120,6 @@ loss_descriptions["inpainter_total_loss"] = inpainter_total_loss
 loss_descriptions["inpainter_reconstruction_L1_loss"] = recon_loss
 loss_descriptions["discriminator_GAN_loss"] = disc_loss
 loss_descriptions["mask_discriminator_loss"] = maskdisc_loss
+loss_descriptions["mask_variance"] = mask_variance
+loss_descriptions["mask_generator_tv_loss"] = maskgen_tv_loss
+loss_descriptions["inpainter_tv_loss"] = inpainter_tv_loss

--- a/decepticon/_losses.py
+++ b/decepticon/_losses.py
@@ -127,3 +127,14 @@ def pixelwise_variance(x):
     pixelwise_mean = tf.reduce_mean(x, 0)
     meandiff = x - tf.expand_dims(pixelwise_mean, 0)
     return tf.reduce_mean(meandiff**2)
+
+
+def total_variation_loss(x):
+    """
+    Input a batch of images; return mean total variation
+    loss.
+    
+    Check out https://en.wikipedia.org/wiki/Total_variation_denoising
+    """
+    vl = tf.image.total_variation(x)
+    return tf.reduce_mean(vl)

--- a/decepticon/_losses.py
+++ b/decepticon/_losses.py
@@ -113,3 +113,17 @@ def compute_style_loss(x, y, style_model):
         loss += K.mean(K.square(x_gram - y_gram)) 
         
     return loss
+
+
+
+def pixelwise_variance(x):
+    """
+    Compute the average variance-per-pixel for
+    a batch of images (to make sure outputs aren't
+    mode-collapsing)
+    
+    :x: an image with batch dimension 0
+    """
+    pixelwise_mean = tf.reduce_mean(x, 0)
+    meandiff = x - tf.expand_dims(pixelwise_mean, 0)
+    return tf.reduce_mean(meandiff**2)

--- a/decepticon/_trainers.py
+++ b/decepticon/_trainers.py
@@ -538,14 +538,15 @@ class Trainer(object):
                 "batch_size":self._batch_size,
                 "class_loss_weight":self.weights["class"],
                 "exponential_loss_weight":self.weights["exp"],
-                "reconstruction_loss_weight":self.weights["recon"],
-                "discriminator_loss_weight":self.weights["disc"],
-                "style_loss_weight":self.weights["style"],
+                "reconstruction_weight":self.weights["recon"],
+                "disc_weight":self.weights["disc"],
+                "style_weight":self.weights["style"],
                 "prior_weight":self.weights["prior"],
                 "clip":self._clip,
                 "imshape":self._imshape,
                 "train_maskgen_on_all":self._train_maskgen_on_all,
-                "learning_rate":self._lr
+                "lr":self._lr,
+                "num_parallel_calls":self._num_parallel_calls
                 }
         config_path = os.path.join(self.logdir, "config.yml")
         yaml.dump(config, open(config_path, "w"), default_flow_style=False)

--- a/decepticon/_trainers.py
+++ b/decepticon/_trainers.py
@@ -8,6 +8,7 @@ import yaml
 
 import decepticon
 from decepticon._losses import least_squares_gan_loss, build_style_model, compute_style_loss
+from decepticon._losses import pixelwise_variance
 from decepticon.loaders import image_loader_dataset, classifier_training_dataset
 from decepticon.loaders import inpainter_training_dataset, circle_mask_dataset
 from decepticon._descriptions import loss_descriptions
@@ -471,6 +472,8 @@ class Trainer(object):
                 #        self.weights["prior"])
                 #maskgen_losses = dict(zip(maskgen_lossnames, maskgen_losses))
                 # record batch of masks to buffer
+                # record the mean pixelwise mask variance
+                self._record_losses(mask_variance=pixelwise_variance(mask))
                 mask_buffer.append(mask.numpy())
                 
                 # run the mask discriminator step (if there is one)

--- a/decepticon/_util.py
+++ b/decepticon/_util.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import tensorflow as tf
+import yaml
+import os
+
+from decepticon._trainers import Trainer
+
+
+def load_trainer_from_saved(posfiles, negfiles, old_dir, new_dir, 
+                           **kwargs):
+    """
+    Build a Trainer object using the log directory from a previous
+    Trainer. Useful for transfer learning experiments.
+    
+    :posfiles: list of paths to positive files
+    :negfiles: list of paths to negative files
+    :old_dir: directory to load from
+    :new_dir: directory to save to
+    :kwargs: pass any keyword arguments to override values
+        in the original directory
+    """
+    # load config.yml find
+    config = yaml.load(open(os.path.join(old_dir, "config.yml")),
+                  Loader=yaml.FullLoader)
+    # load saved models
+    saved_models = {
+        "mask_generator":"mask_generator.h5",
+        "inpainter":"inpainter.h5",
+        "discriminator":"discriminator.h5",
+        "classifier":"classifier.h5",
+        "maskdisc":"mask_discriminator.h5"
+    }
+    files_in_dir = list(os.listdir(old_dir))
+    for m in saved_models:
+        if saved_models[m] in files_in_dir:
+            config[m] = tf.keras.models.load_model(
+                        os.path.join(old_dir, saved_models[m]))
+            
+    for k in kwargs:
+        config[k] = kwargs[k]
+        
+    return Trainer(posfiles, negfiles, 
+                   logdir=new_dir, **config)

--- a/decepticon/_util.py
+++ b/decepticon/_util.py
@@ -41,3 +41,4 @@ def load_trainer_from_saved(posfiles, negfiles, old_dir, new_dir,
         
     return Trainer(posfiles, negfiles, 
                    logdir=new_dir, **config)
+


### PR DESCRIPTION
Made a ton of tiny changes:

* added more details to `config.yml` and standardized so key values in the YAML file line up with keyword arguments for `Trainer`
* added function `decepticon.load_trainer_from_saved()` that auto-loads a `Trainer` from a previous experiment, pointing to a new log directory. You can override any of the kwargs to use this for transfer learning experiments
* fixed the transfer learning bug I've been running into
* updated Poisson circle generator for mask prior to a function that uses overlapping ellipses to generate masks with a distribution of shapes
* broke out `Trainer.fit()` into a series of smaller functions to make it easier to work with
* standardized function for writing Tensorboard scalars
* Tensorboard scalars are now saved once per batch instead of once per epoch, so you can see how losses are evolving with higher granularity
* added a Tensorboard scalar for the average pixelwise mask variance (a measure that should go to zero when we get mask mode collapse- could use this in the future as part of a hyperparameter tuning solution)
* updated `Trainer` to do a better job spreading out the images it picks for evaluation (no longer just the first batch of images in the order you passed them)
* added total variation loss to the inpainter (in the paper) and the mask generator (not in the paper).
  * both are normalized by the image dimensions (haven't checked whether Shetty's code does that)
* added a keyword argument to set the value of masked areas when input to the inpainter- we've been running with them set to 0, so there's no *a priori* way for it to differentiate between a masked area and a dark area with a bunch of black pixels. Currently experimenting with setting the mask to -1 instead.